### PR TITLE
fix(verification): Fix verification should consider selected

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -15,7 +15,7 @@ const Cell = ({ current, showErrors, targets }) => {
     const [selected, setSelected] = useState(empty);
     const classes = classNames("col-md-3 cell", {
         [`target-${selected.idx}`]: selected.idx !== null,
-        error: showErrors && target !== selected.value
+        error: showErrors && selected.idx !== null && target !== selected.value
     });
 
     const handleClick = selection => {


### PR DESCRIPTION
Fixed the issue of verification considering every cell, even if not selected
Now only the cells having selections (i.e. invalid selections) will be marked as invalid and the error will be highlighted
Fixes #31