### PR TITLE
Transition on reset

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -13,6 +13,7 @@ const Cell = ({ current, showErrors, targets }) => {
     const [target, setTarget] = useState(pickOne(targets));
     const [term, setTerm] = useState(pickOne(range(1, target - 1)));
     const [selected, setSelected] = useState(empty);
+    const [isTransitioning, setIsTransitioning] = useState(targets ? true : false);
     const classes = classNames("col-md-3 cell", {
         [`target-${selected.idx}`]: selected.idx !== null,
         error: showErrors && target !== selected.value
@@ -26,10 +27,13 @@ const Cell = ({ current, showErrors, targets }) => {
         setTarget(pickOne(targets));
         setTerm(pickOne(range(1, target - 1)));
         setSelected({ idx: null, value: null });
+        setIsTransitioning(targets ? true : false);
     }, [targets, target]);
 
     return (
-        <CSSTransition in={true} appear={true} timeout={1000} classNames="fade">
+        <CSSTransition in={isTransitioning} appear={true} timeout={1000} classNames="fade" onEntered={(node, isAppearing) => {
+            setIsTransitioning(false);
+        }}>
             <div className={classes} onClick={() => handleClick(current)}>
                 <div className="cell-content">{`${term} + ${target - term}`}</div>
             </div>

--- a/src/components/Reset.js
+++ b/src/components/Reset.js
@@ -15,7 +15,7 @@ const Reset = ({ onClick }) => {
         if (disabled) return;
         onClick();
         setDisabled(true);
-    }, [disabled]);
+    }, [disabled, onClick]);
 
     return (
         <div className="row justify-content-md-center no-gutters">

--- a/src/components/Reset.js
+++ b/src/components/Reset.js
@@ -1,15 +1,32 @@
-import React from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 
-const Reset = ({ onClick }) => (
-    <div className="row justify-content-md-center no-gutters">
-        <div id="reset" className="col-md-auto">
-            <button onClick={onClick} className="btn btn-sm btn-outline-primary">
-                RESET
-            </button>
+const Reset = ({ onClick }) => {
+    const [disabled, setDisabled] = useState(false);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setDisabled(false);
+        }, 1000);
+        return () => clearTimeout(timeout);
+    }, [disabled]);
+
+    const handleClick = useCallback(() => {
+        if (disabled) return;
+        onClick();
+        setDisabled(true);
+    }, [disabled]);
+
+    return (
+        <div className="row justify-content-md-center no-gutters">
+            <div id="reset" className="col-md-auto">
+                <button onClick={handleClick} className="btn btn-sm btn-outline-primary" disabled={disabled}>
+                    RESET
+                </button>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 Reset.propTypes = {
     onClick: PropTypes.func.isRequired

--- a/src/css/App.scss
+++ b/src/css/App.scss
@@ -105,12 +105,12 @@ header {
     padding: 7px;
 }
 
-.fade-appear {
+.fade-appear, .fade-enter {
     opacity: 0;
     z-index: 1;
 }
 
-.fade-appear.fade-appear-active {
+.fade-appear.fade-appear-active, .fade-enter.fade-enter-active {
     opacity: 1;
     transition: opacity 1000ms linear;
 }


### PR DESCRIPTION
Fixes #26. I opted to reflect the transition in the Reset button (disabling it for the duration of the reset) as repeatedly clicking it while a transition was in progress could look pretty ugly. I hope this is okay! Let me know.